### PR TITLE
fix: modify CSP #1

### DIFF
--- a/src/dataProvider.ts
+++ b/src/dataProvider.ts
@@ -683,7 +683,7 @@ function getWebviewContent(cspSource: string, sourceUri: vscode.Uri, plotlyJsUri
 	<meta charset="UTF-8">
 `;
     if (applyCsp) {
-        header += `<meta http-equiv="Content-Security-Policy" content="default-src 'none'; img-src ${cspSource} https:; style-src ${cspSource} 'unsafe-inline'; script-src ${cspSource};">
+        header += `<meta http-equiv="Content-Security-Policy" content="default-src 'none'; img-src blob:; style-src 'unsafe-inline'; script-src ${cspSource};">
 `;
     }
     header += `<title>Preview spec scan</title>


### PR DESCRIPTION
Pushing Plotly.js download button reported an error when CSP was enabled.

I found Plotly.js loads image using `blob:` scheme and so, allowed `img-src blob:` in the content-security-policy in the HTML header.
While this fix reduces the error being reported, the downloaded file is missing.
It may be impossible to create a file from a webview in VS Code since a webview is running in an isolated environment.