### PR TITLE
fix: scroll position not restored when reloaded

### DIFF
--- a/src/dataProvider.ts
+++ b/src/dataProvider.ts
@@ -453,6 +453,8 @@ export class DataProvider implements vscode.FoldingRangeProvider, vscode.Documen
                 panel.webview.postMessage(messageOut);
                 messageOut = { type: 'setScrollBehavior', value: config.get<boolean>('smoothScrolling', true) ? 'smooth' : 'auto' };
                 preview.panel.webview.postMessage(messageOut);
+                messageOut = { type: 'restoreScroll', delay: true };
+                preview.panel.webview.postMessage(messageOut);
             }
         }, null, this.subscriptions);
 

--- a/src/previewTypes.ts
+++ b/src/previewTypes.ts
@@ -37,7 +37,8 @@ export type MessageToWebview =
     | EnableMultipleSelectionMessage
     | EnableRightAxisMessage
     | EnableEditorScrollMessage
-    | SetScrollBehaviorMessage;
+    | SetScrollBehaviorMessage
+    | RestoreScrallMessage;
 
 interface LockPreviewMessage extends BaseMessage {
     type: 'lockPreview';
@@ -82,6 +83,11 @@ interface EnableEditorScrollMessage extends BaseMessage {
 interface SetScrollBehaviorMessage extends BaseMessage {
     type: 'setScrollBehavior';
     value: 'auto' | 'smooth';
+}
+
+interface RestoreScrallMessage extends BaseMessage {
+    type: 'restoreScroll';
+    delay: boolean;
 }
 
 export type MessageFromWebview =


### PR DESCRIPTION
fix #19.

Previously the scroll position of a webview was restored at the end of " DOMContentLoaded" evnet. At the moment graphs are not shown.

With this PR, the scroll position is restored after short delay after the script of the webpage fetches graph data from the main controller of the extension. Currently webview does not strictly wait for the time when Plotly finish drawing graphs and the webpage is resized (since I can't find a way to detect them).